### PR TITLE
Improve layout with shared header/footer

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,6 @@
-import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -24,33 +25,7 @@ export default async function AboutPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-amber-200 sticky top-0 z-10">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center space-x-4">
-              <h1 className="text-3xl font-bold text-amber-800">🌳 Wooden Art</h1>
-              <Badge variant="outline" className="text-amber-700 border-amber-300">
-                Handcrafted
-              </Badge>
-            </Link>
-            <nav className="hidden md:flex space-x-6">
-              <Link href="/" className="text-amber-700 hover:text-amber-900 font-medium">
-                Home
-              </Link>
-              <Link href="/products" className="text-amber-700 hover:text-amber-900 font-medium">
-                Products
-              </Link>
-              <Link href="/about" className="text-amber-700 hover:text-amber-900 font-medium">
-                About
-              </Link>
-              <Link href="/contact" className="text-amber-700 hover:text-amber-900 font-medium">
-                Contact
-              </Link>
-            </nav>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 py-4">
@@ -103,40 +78,7 @@ export default async function AboutPage() {
         </div>
       </div>
 
-      {/* Footer */}
-      <footer className="bg-amber-800 text-white py-12 px-4">
-        <div className="container mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div>
-              <h4 className="text-2xl font-bold mb-4">🌳 Wooden Art</h4>
-              <p className="text-amber-100">
-                Handcrafted wooden pieces made with passion and precision. 
-                Each item tells a story of natural beauty and skilled craftsmanship.
-              </p>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Quick Links</h5>
-              <ul className="space-y-2 text-amber-100">
-                <li><Link href="/" className="hover:text-white">Home</Link></li>
-                <li><Link href="/products" className="hover:text-white">Products</Link></li>
-                <li><Link href="/about" className="hover:text-white">About</Link></li>
-                <li><Link href="/contact" className="hover:text-white">Contact</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Contact Info</h5>
-              <div className="text-amber-100 space-y-2">
-                <p>📧 info@woodenart.com</p>
-                <p>📞 (555) 123-4567</p>
-                <p>📍 123 Craftsman Lane, Woodville</p>
-              </div>
-            </div>
-          </div>
-          <div className="border-t border-amber-700 mt-8 pt-8 text-center text-amber-100">
-            <p>&copy; 2024 Wooden Art. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,4 @@
 import Link from "next/link";
-import SiteHeader from "@/components/SiteHeader";
-import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -25,7 +23,7 @@ export default async function AboutPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      <SiteHeader />
+
 
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 py-4">
@@ -78,7 +76,7 @@ export default async function AboutPage() {
         </div>
       </div>
 
-      <SiteFooter />
+
     </div>
   );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,8 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
-import SiteHeader from "@/components/SiteHeader";
-import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -30,7 +28,7 @@ export default async function ContactPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      <SiteHeader />
+
 
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 py-4">
@@ -179,7 +177,7 @@ export default async function ContactPage() {
         </div>
       </div>
 
-      <SiteFooter />
+
     </div>
   );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,7 +1,8 @@
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -29,33 +30,7 @@ export default async function ContactPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-amber-200 sticky top-0 z-10">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center space-x-4">
-              <h1 className="text-3xl font-bold text-amber-800">🌳 Wooden Art</h1>
-              <Badge variant="outline" className="text-amber-700 border-amber-300">
-                Handcrafted
-              </Badge>
-            </Link>
-            <nav className="hidden md:flex space-x-6">
-              <Link href="/" className="text-amber-700 hover:text-amber-900 font-medium">
-                Home
-              </Link>
-              <Link href="/products" className="text-amber-700 hover:text-amber-900 font-medium">
-                Products
-              </Link>
-              <Link href="/about" className="text-amber-700 hover:text-amber-900 font-medium">
-                About
-              </Link>
-              <Link href="/contact" className="text-amber-700 hover:text-amber-900 font-medium">
-                Contact
-              </Link>
-            </nav>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 py-4">
@@ -204,40 +179,7 @@ export default async function ContactPage() {
         </div>
       </div>
 
-      {/* Footer */}
-      <footer className="bg-amber-800 text-white py-12 px-4 mt-16">
-        <div className="container mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div>
-              <h4 className="text-2xl font-bold mb-4">🌳 Wooden Art</h4>
-              <p className="text-amber-100">
-                Handcrafted wooden pieces made with passion and precision. 
-                Each item tells a story of natural beauty and skilled craftsmanship.
-              </p>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Quick Links</h5>
-              <ul className="space-y-2 text-amber-100">
-                <li><Link href="/" className="hover:text-white">Home</Link></li>
-                <li><Link href="/products" className="hover:text-white">Products</Link></li>
-                <li><Link href="/about" className="hover:text-white">About</Link></li>
-                <li><Link href="/contact" className="hover:text-white">Contact</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Contact Info</h5>
-              <div className="text-amber-100 space-y-2">
-                <p>📧 {contactContent.email}</p>
-                <p>📞 {contactContent.phone}</p>
-                <p>📍 123 Craftsman Lane, Woodville</p>
-              </div>
-            </div>
-          </div>
-          <div className="border-t border-amber-700 mt-8 pt-8 text-center text-amber-100">
-            <p>&copy; 2024 Wooden Art. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -31,7 +33,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <SiteHeader />
         {children}
+        <SiteFooter />
         <Script
           id="netlify-init"
           dangerouslySetInnerHTML={{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
 import ProductCard from "@/components/ProductCard";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import SiteHeader from "@/components/SiteHeader";
-import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -53,7 +51,7 @@ export default async function Home() {
   
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      <SiteHeader />
+
 
       {/* Hero Section */}
       <section className="py-20 px-4">
@@ -119,7 +117,7 @@ export default async function Home() {
         </div>
       </section>
 
-      <SiteFooter />
+
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 import ProductCard from "@/components/ProductCard";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -52,33 +53,7 @@ export default async function Home() {
   
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-amber-200 sticky top-0 z-10">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
-              <h1 className="text-3xl font-bold text-amber-800">🌳 Wooden Art</h1>
-              <Badge variant="outline" className="text-amber-700 border-amber-300">
-                Handcrafted
-              </Badge>
-            </div>
-            <nav className="hidden md:flex space-x-6">
-              <Link href="/" className="text-amber-700 hover:text-amber-900 font-medium">
-                Home
-              </Link>
-              <Link href="/products" className="text-amber-700 hover:text-amber-900 font-medium">
-                Products
-              </Link>
-              <Link href="/about" className="text-amber-700 hover:text-amber-900 font-medium">
-                About
-              </Link>
-              <Link href="/contact" className="text-amber-700 hover:text-amber-900 font-medium">
-                Contact
-              </Link>
-            </nav>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
       <section className="py-20 px-4">
@@ -144,40 +119,7 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-amber-800 text-white py-12 px-4">
-        <div className="container mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div>
-              <h4 className="text-2xl font-bold mb-4">🌳 Wooden Art</h4>
-              <p className="text-amber-100">
-                Handcrafted wooden pieces made with passion and precision. 
-                Each item tells a story of natural beauty and skilled craftsmanship.
-              </p>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Quick Links</h5>
-              <ul className="space-y-2 text-amber-100">
-                <li><Link href="/" className="hover:text-white">Home</Link></li>
-                <li><Link href="/products" className="hover:text-white">Products</Link></li>
-                <li><Link href="/about" className="hover:text-white">About</Link></li>
-                <li><Link href="/contact" className="hover:text-white">Contact</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Contact Info</h5>
-              <div className="text-amber-100 space-y-2">
-                <p>📧 info@woodenart.com</p>
-                <p>📞 (555) 123-4567</p>
-                <p>📍 123 Craftsman Lane, Woodville</p>
-              </div>
-            </div>
-          </div>
-          <div className="border-t border-amber-700 mt-8 pt-8 text-center text-amber-100">
-            <p>&copy; 2024 Wooden Art. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import Image from "next/image";
 import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -72,33 +74,7 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-amber-200 sticky top-0 z-10">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center space-x-4">
-              <h1 className="text-3xl font-bold text-amber-800">🌳 Wooden Art</h1>
-              <Badge variant="outline" className="text-amber-700 border-amber-300">
-                Handcrafted
-              </Badge>
-            </Link>
-            <nav className="hidden md:flex space-x-6">
-              <Link href="/" className="text-amber-700 hover:text-amber-900 font-medium">
-                Home
-              </Link>
-              <Link href="/products" className="text-amber-700 hover:text-amber-900 font-medium">
-                Products
-              </Link>
-              <Link href="/about" className="text-amber-700 hover:text-amber-900 font-medium">
-                About
-              </Link>
-              <Link href="/contact" className="text-amber-700 hover:text-amber-900 font-medium">
-                Contact
-              </Link>
-            </nav>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 py-4">
@@ -227,40 +203,7 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
         </div>
       </div>
 
-      {/* Footer */}
-      <footer className="bg-amber-800 text-white py-12 px-4 mt-16">
-        <div className="container mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div>
-              <h4 className="text-2xl font-bold mb-4">🌳 Wooden Art</h4>
-              <p className="text-amber-100">
-                Handcrafted wooden pieces made with passion and precision. 
-                Each item tells a story of natural beauty and skilled craftsmanship.
-              </p>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Quick Links</h5>
-              <ul className="space-y-2 text-amber-100">
-                <li><Link href="/" className="hover:text-white">Home</Link></li>
-                <li><Link href="/products" className="hover:text-white">Products</Link></li>
-                <li><Link href="/about" className="hover:text-white">About</Link></li>
-                <li><Link href="/contact" className="hover:text-white">Contact</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Contact Info</h5>
-              <div className="text-amber-100 space-y-2">
-                <p>📧 info@woodenart.com</p>
-                <p>📞 (555) 123-4567</p>
-                <p>📍 123 Craftsman Lane, Woodville</p>
-              </div>
-            </div>
-          </div>
-          <div className="border-t border-amber-700 mt-8 pt-8 text-center text-amber-100">
-            <p>&copy; 2024 Wooden Art. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -3,8 +3,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import Image from "next/image";
 import Link from "next/link";
-import SiteHeader from "@/components/SiteHeader";
-import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -74,7 +72,7 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      <SiteHeader />
+
 
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 py-4">
@@ -203,7 +201,7 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
         </div>
       </div>
 
-      <SiteFooter />
+
     </div>
   );
 }

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import Image from "next/image";
 import Link from "next/link";
 import fs from "fs";
@@ -144,35 +145,40 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
                 )}
               </div>
             </div>
-
-            <div className="prose prose-amber max-w-none">
-              <div dangerouslySetInnerHTML={{ __html: product.content.replace(/\n/g, '<br/>') }} />
-            </div>
-
-            {/* Specifications */}
-            <Card>
-              <CardContent className="p-6">
-                <h3 className="text-lg font-semibold text-amber-900 mb-4">Specifications</h3>
-                <dl className="space-y-2">
-                  {product.dimensions && (
-                    <>
-                      <dt className="text-sm font-medium text-amber-700">Dimensions</dt>
-                      <dd className="text-amber-600">{product.dimensions}</dd>
-                    </>
-                  )}
-                  {product.material && (
-                    <>
-                      <dt className="text-sm font-medium text-amber-700">Material</dt>
-                      <dd className="text-amber-600">{product.material}</dd>
-                    </>
-                  )}
-                  <dt className="text-sm font-medium text-amber-700">Availability</dt>
-                  <dd className="text-amber-600">{product.status}</dd>
-                  <dt className="text-sm font-medium text-amber-700">Category</dt>
-                  <dd className="text-amber-600">{product.category}</dd>
-                </dl>
-              </CardContent>
-            </Card>
+            <Tabs defaultValue="details" className="space-y-4">
+              <TabsList>
+                <TabsTrigger value="details">Details</TabsTrigger>
+                <TabsTrigger value="specs">Specifications</TabsTrigger>
+              </TabsList>
+              <TabsContent value="details" className="prose prose-amber max-w-none">
+                <div dangerouslySetInnerHTML={{ __html: product.content.replace(/\n/g, '<br/>') }} />
+              </TabsContent>
+              <TabsContent value="specs">
+                <Card>
+                  <CardContent className="p-6">
+                    <h3 className="text-lg font-semibold text-amber-900 mb-4">Specifications</h3>
+                    <dl className="space-y-2">
+                      {product.dimensions && (
+                        <>
+                          <dt className="text-sm font-medium text-amber-700">Dimensions</dt>
+                          <dd className="text-amber-600">{product.dimensions}</dd>
+                        </>
+                      )}
+                      {product.material && (
+                        <>
+                          <dt className="text-sm font-medium text-amber-700">Material</dt>
+                          <dd className="text-amber-600">{product.material}</dd>
+                        </>
+                      )}
+                      <dt className="text-sm font-medium text-amber-700">Availability</dt>
+                      <dd className="text-amber-600">{product.status}</dd>
+                      <dt className="text-sm font-medium text-amber-700">Category</dt>
+                      <dd className="text-amber-600">{product.category}</dd>
+                    </dl>
+                  </CardContent>
+                </Card>
+              </TabsContent>
+            </Tabs>
 
             {/* Actions */}
             <div className="space-y-4">

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -2,6 +2,8 @@ import ProductCard from "@/components/ProductCard";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -52,33 +54,7 @@ export default async function ProductsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-amber-200 sticky top-0 z-10">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center space-x-4">
-              <h1 className="text-3xl font-bold text-amber-800">🌳 Wooden Art</h1>
-              <Badge variant="outline" className="text-amber-700 border-amber-300">
-                Handcrafted
-              </Badge>
-            </Link>
-            <nav className="hidden md:flex space-x-6">
-              <Link href="/" className="text-amber-700 hover:text-amber-900 font-medium">
-                Home
-              </Link>
-              <Link href="/products" className="text-amber-700 hover:text-amber-900 font-medium">
-                Products
-              </Link>
-              <Link href="/about" className="text-amber-700 hover:text-amber-900 font-medium">
-                About
-              </Link>
-              <Link href="/contact" className="text-amber-700 hover:text-amber-900 font-medium">
-                Contact
-              </Link>
-            </nav>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Page Header */}
       <section className="py-16 px-4">
@@ -150,40 +126,7 @@ export default async function ProductsPage() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-amber-800 text-white py-12 px-4">
-        <div className="container mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div>
-              <h4 className="text-2xl font-bold mb-4">🌳 Wooden Art</h4>
-              <p className="text-amber-100">
-                Handcrafted wooden pieces made with passion and precision. 
-                Each item tells a story of natural beauty and skilled craftsmanship.
-              </p>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Quick Links</h5>
-              <ul className="space-y-2 text-amber-100">
-                <li><Link href="/" className="hover:text-white">Home</Link></li>
-                <li><Link href="/products" className="hover:text-white">Products</Link></li>
-                <li><Link href="/about" className="hover:text-white">About</Link></li>
-                <li><Link href="/contact" className="hover:text-white">Contact</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h5 className="text-lg font-semibold mb-4">Contact Info</h5>
-              <div className="text-amber-100 space-y-2">
-                <p>📧 info@woodenart.com</p>
-                <p>📞 (555) 123-4567</p>
-                <p>📍 123 Craftsman Lane, Woodville</p>
-              </div>
-            </div>
-          </div>
-          <div className="border-t border-amber-700 mt-8 pt-8 text-center text-amber-100">
-            <p>&copy; 2024 Wooden Art. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -2,8 +2,6 @@ import ProductCard from "@/components/ProductCard";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import SiteHeader from "@/components/SiteHeader";
-import SiteFooter from "@/components/SiteFooter";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -54,7 +52,7 @@ export default async function ProductsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
-      <SiteHeader />
+
 
       {/* Page Header */}
       <section className="py-16 px-4">
@@ -126,7 +124,7 @@ export default async function ProductsPage() {
         </div>
       </section>
 
-      <SiteFooter />
+
     </div>
   );
 }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,5 +1,4 @@
-import ProductCard from "@/components/ProductCard";
-import { Badge } from "@/components/ui/badge";
+import ProductGrid from "@/components/ProductGrid";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import fs from "fs";
@@ -65,17 +64,7 @@ export default async function ProductsPage() {
             Each item is unique and made with the finest attention to detail.
           </p>
           
-          {/* Categories */}
-          <div className="flex flex-wrap justify-center gap-2 mb-8">
-            <Badge variant="default" className="bg-amber-600 text-white px-4 py-2">
-              All Products ({products.length})
-            </Badge>
-            {categories.map((category) => (
-              <Badge key={category} variant="outline" className="border-amber-300 text-amber-700 px-4 py-2">
-                {category} ({products.filter(p => p.category === category).length})
-              </Badge>
-            ))}
-          </div>
+          <p className="text-amber-600">Choose a category to filter the catalog.</p>
         </div>
       </section>
 
@@ -83,11 +72,7 @@ export default async function ProductsPage() {
       <section className="py-16 px-4 bg-white/50">
         <div className="container mx-auto">
           {products.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {products.map((product) => (
-                <ProductCard key={product._sys.filename} product={product} />
-              ))}
-            </div>
+            <ProductGrid products={products} categories={categories} />
           ) : (
             <div className="text-center py-12">
               <div className="text-6xl mb-4">🌳</div>

--- a/src/components/ProductGrid.tsx
+++ b/src/components/ProductGrid.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useState } from 'react'
+import ProductCard from './ProductCard'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from './ui/select'
+
+interface Product {
+  _sys: { filename: string }
+  name: string
+  description: string
+  price: number
+  category: string
+  featured_image: string
+  material: string
+  available: boolean
+  featured: boolean
+  status: string
+}
+
+export default function ProductGrid({
+  products,
+  categories,
+}: {
+  products: Product[]
+  categories: string[]
+}) {
+  const [filter, setFilter] = useState('all')
+
+  const filtered =
+    filter === 'all'
+      ? products
+      : products.filter((p) => p.category === filter)
+
+  return (
+    <div>
+      <div className="flex justify-end mb-6">
+        <Select defaultValue="all" onValueChange={setFilter}>
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder="Filter by category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Products ({products.length})</SelectItem>
+            {categories.map((category) => (
+              <SelectItem key={category} value={category}>
+                {category} ({products.filter((p) => p.category === category).length})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {filtered.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {filtered.map((product) => (
+            <ProductCard key={product._sys.filename} product={product} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-center text-amber-600">No products found.</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+export default function SiteFooter() {
+  return (
+    <footer className="bg-amber-800 text-white py-12 px-4">
+      <div className="container mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div>
+            <h4 className="text-2xl font-bold mb-4">🌳 Wooden Art</h4>
+            <p className="text-amber-100">
+              Handcrafted wooden pieces made with passion and precision. Each item tells a story of natural beauty and skilled craftsmanship.
+            </p>
+          </div>
+          <div>
+            <h5 className="text-lg font-semibold mb-4">Quick Links</h5>
+            <ul className="space-y-2 text-amber-100">
+              <li><Link href="/" className="hover:text-white">Home</Link></li>
+              <li><Link href="/products" className="hover:text-white">Products</Link></li>
+              <li><Link href="/about" className="hover:text-white">About</Link></li>
+              <li><Link href="/contact" className="hover:text-white">Contact</Link></li>
+            </ul>
+          </div>
+          <div>
+            <h5 className="text-lg font-semibold mb-4">Contact Info</h5>
+            <div className="text-amber-100 space-y-2">
+              <p>📧 info@woodenart.com</p>
+              <p>📞 (555) 123-4567</p>
+              <p>📍 123 Craftsman Lane, Woodville</p>
+            </div>
+          </div>
+        </div>
+        <div className="border-t border-amber-700 mt-8 pt-8 text-center text-amber-100">
+          <p>&copy; 2024 Wooden Art. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,45 @@
+"use client";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { Menu } from "lucide-react";
+
+export default function SiteHeader() {
+  return (
+    <header className="bg-white/80 backdrop-blur-sm border-b border-amber-200 sticky top-0 z-10">
+      <div className="container mx-auto px-4 py-4">
+        <div className="flex items-center justify-between">
+          <Link href="/" className="flex items-center space-x-4">
+            <h1 className="text-3xl font-bold text-amber-800">🌳 Wooden Art</h1>
+            <Badge variant="outline" className="text-amber-700 border-amber-300">Handcrafted</Badge>
+          </Link>
+          <nav className="hidden md:flex space-x-6">
+            <Link href="/" className="text-amber-700 hover:text-amber-900 font-medium">Home</Link>
+            <Link href="/products" className="text-amber-700 hover:text-amber-900 font-medium">Products</Link>
+            <Link href="/about" className="text-amber-700 hover:text-amber-900 font-medium">About</Link>
+            <Link href="/contact" className="text-amber-700 hover:text-amber-900 font-medium">Contact</Link>
+          </nav>
+          <div className="md:hidden">
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <Menu />
+                  <span className="sr-only">Open menu</span>
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="p-0 w-full max-w-xs" showCloseButton={false}>
+                <nav className="grid gap-4 p-6 text-amber-700">
+                  <Link href="/">Home</Link>
+                  <Link href="/products">Products</Link>
+                  <Link href="/about">About</Link>
+                  <Link href="/contact">Contact</Link>
+                </nav>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+
+import { cn } from '@/lib/utils'
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary
- add `SiteHeader` and `SiteFooter` components using shadcn UI
- refactor all pages to use the new header and footer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686cecb4f574832f97412d85543846a7